### PR TITLE
Showing proposed solution only when it is actionable

### DIFF
--- a/django_query_profiler/query_profiler_storage/__init__.py
+++ b/django_query_profiler/query_profiler_storage/__init__.py
@@ -13,7 +13,7 @@ import re
 import typing
 from collections import Counter, OrderedDict, defaultdict
 from dataclasses import asdict, dataclass, field
-from enum import Enum, auto
+from enum import Enum
 from typing import Callable, Dict, Optional, Tuple
 
 from django.utils.functional import cached_property
@@ -44,12 +44,15 @@ class StackTraceElement:
 
 
 class QuerySignatureAnalyzeResult(Enum):
-    UNKNOWN = auto()
-    MISSING_SELECT_RELATED = auto()
-    GET = auto()
-    MISSING_PREFETCH_RELATED = auto()
-    PREFETCHED_RELATED = auto()
-    FILTER = auto()
+    UNKNOWN = False
+    MISSING_SELECT_RELATED = True
+    GET = False
+    MISSING_PREFETCH_RELATED = True
+    PREFETCHED_RELATED = True
+    FILTER = False
+
+    def __init__(self, visible_in_ui):
+        self.visible_in_ui = visible_in_ui
 
 
 @dataclass(frozen=True)

--- a/django_query_profiler/templates/django_query_profiler_level_query_signature.html
+++ b/django_query_profiler/templates/django_query_profiler_level_query_signature.html
@@ -172,12 +172,16 @@
                                 </div>
 
                                 <div class="col-sm-6">
-                                    <div style="padding-top: 30px; font-size: 12px">
-                                        <b>TL;DR&nbsp;</b>
-                                        <span>
-                                            {{ query_signature.analysis.name }}
-                                        </span>
-                                    </div>
+                                  <b>Recommendation?&nbsp;</b>
+                                  <div style="padding-top: 30px; font-size: 12px">
+                                    {% if query_signature.analysis.visible_in_ui %}
+                                      <span>
+                                          {{ query_signature.analysis.name }}
+                                      </span>
+                                    {% else %}
+                                      <span>None</span>
+                                    {% endif %}
+                                  </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
1. In the detailed view, we should show recommendation for decreasing
queries only when it is one of select_related or prefetch_related
2. Adding a constructor param to enum for visible_in_ui to see if we
should show the recommendation in chrome plugin