### PR TITLE
Fixing master with latest changes for dependent packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,9 @@ tests_require =
 install_requires =
     setuptools
     django
-    moz-sql-parser
+    ; This was causing problems with versions with all version of pythons with conflicting package
+    ; issues.  Freezing the version because this version works
+    moz-sql-parser==3.32.20026
     redis
     mmh3
     isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,9 +53,9 @@ install_requires =
     dataclasses; python_version < "3.7"
 python_requires = >=3.6
 
-[options.packages.find]
-exclude =
-    tests
+;[options.packages.find]
+;exclude =
+;    tests
 
 [bdist_wheel]
 universal = true

--- a/tests/integration/test_data_collector_nesting.py
+++ b/tests/integration/test_data_collector_nesting.py
@@ -30,7 +30,8 @@ class QueryProfilerQueryAndQuerySignatureTest(TestCase):
 
         with QueryProfiler(QueryProfilerLevel.QUERY) as qp_query:
             str(Pizza.objects.all())
-            self.assertEqual(data_collector_thread_local_storage._current_query_profiler_level, QueryProfilerLevel.QUERY)
+            self.assertEqual(data_collector_thread_local_storage._current_query_profiler_level,
+                             QueryProfilerLevel.QUERY)
         self.assertIsNone(data_collector_thread_local_storage._current_query_profiler_level)
 
         self.assertEqual(qp_query_signature.query_profiled_data.summary.total_query_count, 4)
@@ -43,7 +44,8 @@ class QueryProfilerQueryAndQuerySignatureTest(TestCase):
 
         with QueryProfiler(QueryProfilerLevel.QUERY) as qp_query:
             str(Pizza.objects.all())
-            self.assertEqual(data_collector_thread_local_storage._current_query_profiler_level, QueryProfilerLevel.QUERY)
+            self.assertEqual(data_collector_thread_local_storage._current_query_profiler_level,
+                             QueryProfilerLevel.QUERY)
         self.assertIsNone(data_collector_thread_local_storage._current_query_profiler_level)
 
         with QueryProfiler(QueryProfilerLevel.QUERY_SIGNATURE) as qp_query_signature:
@@ -59,7 +61,7 @@ class QueryProfilerQueryAndQuerySignatureTest(TestCase):
 
     def test_query_nested_by_another_query(self):
 
-        with QueryProfiler(QueryProfilerLevel.QUERY) as qp_query:
+        with QueryProfiler(QueryProfilerLevel.QUERY):
             str(Pizza.objects.all())
             self.assertEqual(data_collector_thread_local_storage._current_query_profiler_level,
                              QueryProfilerLevel.QUERY)

--- a/tests/testapp/food/apps.py
+++ b/tests/testapp/food/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class TestAppConfig(AppConfig):
-    name = 'django_query_profiler.tests.testapp.food'
+    name = 'tests.testapp.food'
     verbose_name = 'TestApp'

--- a/tests/testapp/mysql_settings.py
+++ b/tests/testapp/mysql_settings.py
@@ -1,6 +1,6 @@
 import os
 
-from django_query_profiler.settings import *
+from django_query_profiler.settings import *  # noqa
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/testapp/oracle_settings.py
+++ b/tests/testapp/oracle_settings.py
@@ -1,6 +1,6 @@
 import os
 
-from django_query_profiler.settings import *
+from django_query_profiler.settings import * # noqa
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/testapp/postgresql_settings.py
+++ b/tests/testapp/postgresql_settings.py
@@ -1,6 +1,6 @@
 import os
 
-from django_query_profiler.settings import *
+from django_query_profiler.settings import * # noqa
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/testapp/sqlite_settings.py
+++ b/tests/testapp/sqlite_settings.py
@@ -1,6 +1,6 @@
 import os
 
-from django_query_profiler.settings import *
+from django_query_profiler.settings import * # noqa
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist = true
 skip_missing_interpreters = true
 envlist =
     lint-py{37}
-    py{38,37,36}-{djangotip,django22,django21}-{sqlite,postgresql,mysql}
+    py{38,37,36}-{django31,django22,django21}-{sqlite,postgresql,mysql}
     isort-py{37}
     coverage-report
 
@@ -24,7 +24,7 @@ commands =
   coverage run setup.py test
 deps =
   codecov
-  djangotip: https://github.com/django/django/archive/master.tar.gz
+  django31: Django>=3.1.3,<3.2
   django22: Django>=2.2.0,<2.3.0
   django21: Django>=2.1.0,<2.2.0
   postgresql: psycopg2-binary

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist = true
 skip_missing_interpreters = true
 envlist =
     lint-py{37}
-    py{38,37,36}-{django31,django22,django21}-{sqlite,postgresql,mysql}
+    py{38,37,36}-{djangotip,django31,django22,django21}-{sqlite,postgresql,mysql}
     isort-py{37}
     coverage-report
 
@@ -24,6 +24,7 @@ commands =
   coverage run setup.py test
 deps =
   codecov
+  djangotip: https://github.com/django/django/archive/master.tar.gz
   django31: Django>=3.1.3,<3.2
   django22: Django>=2.2.0,<2.3.0
   django21: Django>=2.1.0,<2.2.0


### PR DESCRIPTION
- Was getting some package incompatibility error for mo-future
- We are not using the package directly
- Maybe it means we should have a requirements.txt file ?
- Figured out the version used by running pip freeze
- Added fix for djangotip
- Fixed for flake8