### PR TITLE
Changed "ms" to "μs" for reporting query time

### DIFF
--- a/django_query_profiler/templates/django_query_profiler_level_query.html
+++ b/django_query_profiler/templates/django_query_profiler_level_query.html
@@ -20,7 +20,7 @@
     <body>
 
         <div class="container-fluid">
-            <h2>Summary of the api</h2>
+            <h2>Summary of the API</h2>
 
             <table class="table table-striped table-dark table-bordered">
                 <thead>
@@ -36,7 +36,7 @@
                     <tr>
                         <th>Total</th>
                         <th>{{ summary.total_query_count|commafy }}</th>
-                        <th>{{ summary.total_query_execution_time_in_micros|commafy }} ms</th>
+                        <th>{{ summary.total_query_execution_time_in_micros|commafy }} μs</th>
                         <th>{{ summary.total_db_row_count|commafy }}</th>
                         <th>{{ summary.exact_query_duplicates|commafy }}</th>
                     </tr>

--- a/django_query_profiler/templates/django_query_profiler_level_query_signature.html
+++ b/django_query_profiler/templates/django_query_profiler_level_query_signature.html
@@ -37,7 +37,7 @@
     <body>
 
         <div class="container-fluid">
-            <h2>Summary of the api</h2>
+            <h2>Summary of the API</h2>
 
             <table class="table table-striped table-dark table-bordered">
                 <thead>
@@ -54,7 +54,7 @@
                     <tr>
                         <th>Total</th>
                         <th>{{ summary.total_query_count|commafy }}</th>
-                        <th>{{ summary.total_query_execution_time_in_micros|commafy }} ms</th>
+                        <th>{{ summary.total_query_execution_time_in_micros|commafy }} μs</th>
                         <th>{{ summary.total_db_row_count|commafy }}</th>
                         <th>{{ summary.potential_n_plus1_query_count|commafy }}</th>
                         <th>{{ summary.exact_query_duplicates|commafy }}</th>
@@ -101,7 +101,7 @@
                                 <strong><em>Database rows</em></strong>
                             </div>
                             <div class="col-sm-2">
-                                <strong><em>is N+1?</em></strong>
+                                <strong><em>Is N+1?</em></strong>
                             </div>
                         </h3>
                     </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-query-profiler
-version = 0.4
+version = 0.5
 description = Django query profiler
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
The abbreviation "ms" is milliseconds while the abbreviation "μs" is microseconds.  There are 1,000 microseconds in a millesecond.  The value of the variable it is referencing is also called `total_query_execution_time_in_micros`.  I did a cursory check of the logic behind this variable to verify it _is_ reporting in microseconds:

`query_execution_time_in_micros = int((end_time - start_time) * 1000 * 1000)`

`end_time - start_time` is in seconds, multiply by 1,000 is in milleseconds and multiplying again by 1,000 is in microseconds. 👍

While I was in these files, I also fixed some casing of words/acronyms that I saw.