### PR TITLE
Adding support for new version of Django and fix for issue#19

### DIFF
--- a/django_query_profiler/django/db/backends/mysql/base.py
+++ b/django_query_profiler/django/db/backends/mysql/base.py
@@ -9,4 +9,8 @@ class DatabaseWrapper(mysql_base.DatabaseWrapper, QueryProfilerDatabaseWrapperMi
 
     @staticmethod
     def db_row_count(cursor) -> Optional[int]:
-        return cursor.rowcount if not cursor.connection.errno() else -1
+        try:
+            if cursor.connection.errno():  # Not all mysql drivers have this attribute.  See Issue#19
+                return -1
+        except AttributeError:
+            return cursor.rowcount

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-query-profiler
-version = 0.6
+version = 0.7
 description = Django query profiler
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -16,6 +16,8 @@ classifiers =
     Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -24,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist = true
 skip_missing_interpreters = true
 envlist =
     lint-py{37}
-    py{39,38,37,36}-{djangotip,django32,django31,django22,django21}-{sqlite,postgresql,mysql}
+    py{39,38,37,36}-{django32,django31,django22,django21}-{sqlite,postgresql,mysql}
     isort-py{37}
     coverage-report
 
@@ -24,7 +24,7 @@ commands =
   coverage run setup.py test
 deps =
   codecov
-  djangotip: https://github.com/django/django/archive/master.tar.gz
+;  djangotip: https://github.com/django/django/archive/main.tar.gz  ;  Removing for now
   django32: Django>=3.2,<3.3
   django31: Django>=3.1.3,<3.2
   django22: Django>=2.2.0,<2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist = true
 skip_missing_interpreters = true
 envlist =
     lint-py{37}
-    py{39,38,37,36}-{djangotip,django31,django22,django21}-{sqlite,postgresql,mysql}
+    py{39,38,37,36}-{djangotip,django32,django31,django22,django21}-{sqlite,postgresql,mysql}
     isort-py{37}
     coverage-report
 
@@ -25,6 +25,7 @@ commands =
 deps =
   codecov
   djangotip: https://github.com/django/django/archive/master.tar.gz
+  django32: Django>=3.2,<3.3
   django31: Django>=3.1.3,<3.2
   django22: Django>=2.2.0,<2.3.0
   django21: Django>=2.1.0,<2.2.0


### PR DESCRIPTION
- Django latest version is 3.2.  Adding to tests on travisCI
- [Issue#19](https://github.com/django-query-profiler/django-query-profiler/issues/19) fix for supporting Mysql drivers where db_row_count was throwing exception