### PR TITLE
Unit prefixes and acronyms

### DIFF
--- a/django_query_profiler/templates/django_query_profiler_level_query.html
+++ b/django_query_profiler/templates/django_query_profiler_level_query.html
@@ -46,7 +46,7 @@
 
 
         <div class="container-fluid">
-            <h2>Api Details by query</h2>
+            <h2>API Details by query</h2>
 
             <div class="panel-group">
                 <div class="panel panel-default">
@@ -82,7 +82,7 @@
                                 <!-- Sql TIME -->
                                 <div class="col-sm-4">
                                     <span class="badge">
-                                        {{ query_signature_statistics.query_execution_time_in_micros|commafy }} ms
+                                        {{ query_signature_statistics.query_execution_time_in_micros|commafy }} μs
                                     </span>
                                 </div>
 

--- a/django_query_profiler/templates/django_query_profiler_level_query_signature.html
+++ b/django_query_profiler/templates/django_query_profiler_level_query_signature.html
@@ -65,7 +65,7 @@
 
 
         <div class="container-fluid">
-            <h2>Api Details by query signature</h2>
+            <h2>API Details by query signature</h2>
 
 						<!-- flamegraph -->
 						<div id="chart" style="margin: 10px 20px;"></div>
@@ -130,7 +130,7 @@
                                 <!-- Sql TIME -->
                                 <div class="col-sm-2">
                                     <span class="badge">
-                                        {{ query_signature_statistics.query_execution_time_in_micros|commafy }} ms
+                                        {{ query_signature_statistics.query_execution_time_in_micros|commafy }} μs
                                     </span>
                                 </div>
 


### PR DESCRIPTION
Corrected the unit prefix for microseconds and casing for the acronym "API"

Similar changes to 83c62f47a9fd83642793312f1fd12cabd5f623b5